### PR TITLE
Make the annotation processor "aggregating"

### DIFF
--- a/viewmodel-inject-processor/src/main/java/com/vikingsen/inject/viewmodel/processor/ViewModelInjectProcessor.kt
+++ b/viewmodel-inject-processor/src/main/java/com/vikingsen/inject/viewmodel/processor/ViewModelInjectProcessor.kt
@@ -45,7 +45,7 @@ import javax.lang.model.util.Types
 import javax.tools.Diagnostic.Kind.ERROR
 import javax.tools.Diagnostic.Kind.WARNING
 
-@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.ISOLATING)
+@IncrementalAnnotationProcessor(IncrementalAnnotationProcessorType.AGGREGATING)
 @AutoService(Processor::class)
 class ViewModelInjectProcessor : AbstractProcessor() {
 


### PR DESCRIPTION
The processor is creating a Dagger module with all the generated
factories, so the correct category is "aggregating".